### PR TITLE
Fix Accumulator addressing not being picked up

### DIFF
--- a/65C02-tool.ino
+++ b/65C02-tool.ino
@@ -179,7 +179,7 @@ const ADDRESSMODE ADDRESSMODES[] =
   { " $%04x,X", 2 },       // AM_ABS_X       Absolute Indexed with X     a,x
   { " $%04x,Y", 2 },       // AM_ABS_Y       Absolute Indexed with Y     a,y
   { " ($%04x)", 2 },       // AM_ABS_IDR     Absolute Indirect           (a)
-  { " A", 2 },             // AM_ACC         Accumulator                 A
+  { " A", 1 },             // AM_ACC         Accumulator                 A
   { " #$%02hx", 1 },       // AM_IMM         Immediate Addressing        #
   { "", 0 },               // AM_IMP         Implied                     i
   { " $%02hx", 1 },        // AM_REL         Program Counter Relative    r

--- a/65C02-tool.ino
+++ b/65C02-tool.ino
@@ -179,7 +179,7 @@ const ADDRESSMODE ADDRESSMODES[] =
   { " $%04x,X", 2 },       // AM_ABS_X       Absolute Indexed with X     a,x
   { " $%04x,Y", 2 },       // AM_ABS_Y       Absolute Indexed with Y     a,y
   { " ($%04x)", 2 },       // AM_ABS_IDR     Absolute Indirect           (a)
-  { " A", 1 },             // AM_ACC         Accumulator                 A
+  { " A", 0 },             // AM_ACC         Accumulator                 A
   { " #$%02hx", 1 },       // AM_IMM         Immediate Addressing        #
   { "", 0 },               // AM_IMP         Implied                     i
   { " $%02hx", 1 },        // AM_REL         Program Counter Relative    r


### PR DESCRIPTION
When using the `ROR`, `ROL`, and `LSR` commands. The monitor will not pick them up.

This is because Accumulator mode only requires one byte, that being the opcode it's self.

As seen from [http://www.6502.org/tutorials/6502opcodes.html#ROR](http://www.6502.org/tutorials/6502opcodes.html#ROR)
`Accumulator   ROL A         $2A  1`

The `$2A` instruction variant for `ROR` command does not need any other arguments, and as such, is currently not being picked up.
This is because the Accumulator addressing mode requires `0` additional args, and this program is currently trying to listen for `2` additional args.

This PR fixes this functionality.